### PR TITLE
Fixed missing return in function

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -96,7 +96,7 @@ let findLimitedEditionTiles = function() {
 }
 
 let hasLimitedEditionTiles = function() {
-  findLimitedEditionTiles().length != 0
+  return findLimitedEditionTiles().length != 0
 }
 
 let findLimitedEditionDataForTile = function(data, tile) {


### PR DESCRIPTION
The extension was only working when it observed changes, but with other
extensions loaded, it would often run *after* the tiles were loaded and fail
due to this missing return.